### PR TITLE
[BUG] CD 헬스 체크 실패 해결 - Actuator 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -21,3 +21,10 @@ server:
 logging:
   level:
     org.hibernate.SQL: DEBUG
+
+# Actuator
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info


### PR DESCRIPTION
## 개요
CD 파이프라인의 헬스 체크 실패 문제를 해결하기 위해 Spring Boot Actuator 의존성을 추가함

Closes #24

## 변경 사항
* `build.gradle`: spring-boot-starter-actuator 의존성 추가
* `application.yml`: Actuator 엔드포인트 노출 설정 추가
  - health, info 엔드포인트 활성화

## 영향 범위
* CD 워크플로우: /actuator/health 엔드포인트로 백엔드 상태 확인 가능
* 향후 Prometheus 연동 시 확장 용이

## 테스트 관점
* main 브랜치 머지 후 CD 워크플로우가 정상 완료되는지 확인
* http://<EC2_IP>:8080/actuator/health 접속 시 {"status":"UP"} 응답 확인

---

## AI 협업 섹션

### 협업 방식
* Claude Code와 페어 프로그래밍으로 버그 분석 및 수정 진행
* commit-convention.md, pull-request.md 참조하여 작업

### 주요 대화
> "어큐레이터 달면 머가 좋아?"
- Actuator의 기능(health, metrics, prometheus) 및 포트폴리오 관점의 이점 설명

### AI 기여 사항
* CD 헬스 체크 실패 원인 분석 (Actuator 미설정)
* GitHub Issue #24 생성
* 의존성 추가 및 설정 파일 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 애플리케이션 헬스 체크 엔드포인트 추가 - 서비스 상태를 모니터링할 수 있습니다
  * 애플리케이션 정보 조회 엔드포인트 추가

* **개선**
  * 애플리케이션 모니터링 및 운영 기능 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->